### PR TITLE
build: add publish configuration

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,1 +1,2 @@
 releaseType: node
+handleGHRelease: true

--- a/synth.py
+++ b/synth.py
@@ -32,7 +32,7 @@ for version in versions:
     },
     proto_path='/google/cloud/secrets/v1beta1',
     version=version)
-s.copy(library, excludes=['package.json', 'README.md', 'linkinator.config.json'])
+s.copy(library, excludes=['package.json', 'README.md', '.github/release-please.yml'])
 
 # Copy common templates
 common_templates = gcp.CommonTemplates()


### PR DESCRIPTION
adds a configuration file indicating that a bot should be used for publication.