### PR TITLE
fix(build): switches to using autorelease for docs

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,1 @@
 releaseType: node
-handleGHRelease: true

--- a/synth.py
+++ b/synth.py
@@ -32,7 +32,7 @@ for version in versions:
     },
     proto_path='/google/cloud/secrets/v1beta1',
     version=version)
-s.copy(library, excludes=['package.json', 'README.md', '.github/release-please.yml'])
+s.copy(library, excludes=['package.json', 'README.md'])
 
 # Copy common templates
 common_templates = gcp.CommonTemplates()


### PR DESCRIPTION
we are now able to use the autorelease machinery for `docs`/`tagging`, while leaning on a GitHub app for publication.