### PR TITLE
feat: deferred client initialization

### DIFF
--- a/src/v1beta1/secret_manager_service_client.ts
+++ b/src/v1beta1/secret_manager_service_client.ts
@@ -40,8 +40,8 @@ const version = require('../../../package.json').version;
  *  Manages secrets and operations using those secrets. Implements a REST
  *  model with the following objects:
  *
- *  * [Secret][google.cloud.secrets.v1beta1.Secret]
- *  * [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]
+ *  * {@link google.cloud.secrets.v1beta1.Secret|Secret}
+ *  * {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}
  * @class
  * @memberof v1beta1
  */
@@ -50,8 +50,13 @@ export class SecretManagerServiceClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  secretManagerServiceStub: Promise<{[name: string]: Function}>;
+  secretManagerServiceStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of SecretManagerServiceClient.
@@ -75,8 +80,6 @@ export class SecretManagerServiceClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -106,26 +109,29 @@ export class SecretManagerServiceClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this
       .constructor as typeof SecretManagerServiceClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -141,7 +147,7 @@ export class SecretManagerServiceClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -149,10 +155,10 @@ export class SecretManagerServiceClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      secretPathTemplate: new gaxModule.PathTemplate(
+      secretPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/secrets/{secret}'
       ),
-      secretVersionPathTemplate: new gaxModule.PathTemplate(
+      secretVersionPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/secrets/{secret}/versions/{secret_version}'
       ),
     };
@@ -161,12 +167,12 @@ export class SecretManagerServiceClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listSecrets: new gaxModule.PageDescriptor(
+      listSecrets: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'secrets'
       ),
-      listSecretVersions: new gaxModule.PageDescriptor(
+      listSecretVersions: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'versions'
@@ -174,7 +180,7 @@ export class SecretManagerServiceClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.cloud.secrets.v1beta1.SecretManagerService',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -185,17 +191,36 @@ export class SecretManagerServiceClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.secretManagerServiceStub) {
+      return this.secretManagerServiceStub;
+    }
 
     // Put together the "service stub" for
     // google.cloud.secrets.v1beta1.SecretManagerService.
-    this.secretManagerServiceStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.secretManagerServiceStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.cloud.secrets.v1beta1.SecretManagerService'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.cloud.secrets.v1beta1.SecretManagerService,
-      opts
+          (this._protos as any).google.cloud.secrets.v1beta1
+            .SecretManagerService,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -231,9 +256,9 @@ export class SecretManagerServiceClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -247,6 +272,8 @@ export class SecretManagerServiceClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.secretManagerServiceStub;
   }
 
   /**
@@ -319,17 +346,17 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Creates a new [Secret][google.cloud.secrets.v1beta1.Secret] containing no [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
+   * Creates a new {@link google.cloud.secrets.v1beta1.Secret|Secret} containing no {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersions}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
    *   Required. The resource name of the project to associate with the
-   *   [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+   *   {@link google.cloud.secrets.v1beta1.Secret|Secret}, in the format `projects/*`.
    * @param {string} request.secretId
    *   Required. This must be unique within the project.
    * @param {google.cloud.secrets.v1beta1.Secret} request.secret
-   *   A [Secret][google.cloud.secrets.v1beta1.Secret] with initial field values.
+   *   A {@link google.cloud.secrets.v1beta1.Secret|Secret} with initial field values.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -374,6 +401,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createSecret(request, options, callback);
   }
   addSecretVersion(
@@ -400,16 +428,16 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Creates a new [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] containing secret data and attaches
-   * it to an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+   * Creates a new {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} containing secret data and attaches
+   * it to an existing {@link google.cloud.secrets.v1beta1.Secret|Secret}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to associate with the
-   *   [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format `projects/* /secrets/*`.
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.Secret|Secret} to associate with the
+   *   {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} in the format `projects/* /secrets/*`.
    * @param {google.cloud.secrets.v1beta1.SecretPayload} request.payload
-   *   Required. The secret payload of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   *   Required. The secret payload of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -458,6 +486,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.addSecretVersion(request, options, callback);
   }
   getSecret(
@@ -480,12 +509,12 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Gets metadata for a given [Secret][google.cloud.secrets.v1beta1.Secret].
+   * Gets metadata for a given {@link google.cloud.secrets.v1beta1.Secret|Secret}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
-   *   Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/* /secrets/*`.
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.Secret|Secret}, in the format `projects/* /secrets/*`.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -530,6 +559,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getSecret(request, options, callback);
   }
   updateSecret(
@@ -552,12 +582,12 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Updates metadata of an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+   * Updates metadata of an existing {@link google.cloud.secrets.v1beta1.Secret|Secret}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {google.cloud.secrets.v1beta1.Secret} request.secret
-   *   Required. [Secret][google.cloud.secrets.v1beta1.Secret] with updated field values.
+   *   Required. {@link google.cloud.secrets.v1beta1.Secret|Secret} with updated field values.
    * @param {google.protobuf.FieldMask} request.updateMask
    *   Required. Specifies the fields to be updated.
    * @param {object} [options]
@@ -604,6 +634,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       'secret.name': request.secret!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateSecret(request, options, callback);
   }
   deleteSecret(
@@ -626,12 +657,12 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
+   * Deletes a {@link google.cloud.secrets.v1beta1.Secret|Secret}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
-   *   Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to delete in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.Secret|Secret} to delete in the format
    *   `projects/* /secrets/*`.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -677,6 +708,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteSecret(request, options, callback);
   }
   getSecretVersion(
@@ -703,18 +735,18 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Gets metadata for a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   * Gets metadata for a {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    *
    * `projects/* /secrets/* /versions/latest` is an alias to the `latest`
-   * [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   * {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
-   *   Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} in the format
    *   `projects/* /secrets/* /versions/*`.
    *   `projects/* /secrets/* /versions/latest` is an alias to the `latest`
-   *   [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   *   {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -763,6 +795,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getSecretVersion(request, options, callback);
   }
   accessSecretVersion(
@@ -789,15 +822,15 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Accesses a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]. This call returns the secret data.
+   * Accesses a {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}. This call returns the secret data.
    *
    * `projects/* /secrets/* /versions/latest` is an alias to the `latest`
-   * [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   * {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
-   *   Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} in the format
    *   `projects/* /secrets/* /versions/*`.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -847,6 +880,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.accessSecretVersion(request, options, callback);
   }
   disableSecretVersion(
@@ -873,15 +907,15 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Disables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   * Disables a {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    *
-   * Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-   * [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
+   * Sets the {@link google.cloud.secrets.v1beta1.SecretVersion.state|state} of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} to
+   * {@link google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED|DISABLED}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
-   *   Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to disable in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} to disable in the format
    *   `projects/* /secrets/* /versions/*`.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -931,6 +965,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.disableSecretVersion(request, options, callback);
   }
   enableSecretVersion(
@@ -957,15 +992,15 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Enables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   * Enables a {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    *
-   * Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-   * [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
+   * Sets the {@link google.cloud.secrets.v1beta1.SecretVersion.state|state} of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} to
+   * {@link google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED|ENABLED}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
-   *   Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to enable in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} to enable in the format
    *   `projects/* /secrets/* /versions/*`.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1015,6 +1050,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.enableSecretVersion(request, options, callback);
   }
   destroySecretVersion(
@@ -1041,16 +1077,16 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Destroys a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+   * Destroys a {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion}.
    *
-   * Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-   * [DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+   * Sets the {@link google.cloud.secrets.v1beta1.SecretVersion.state|state} of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} to
+   * {@link google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED|DESTROYED} and irrevocably destroys the
    * secret data.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.name
-   *   Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to destroy in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersion} to destroy in the format
    *   `projects/* /secrets/* /versions/*`.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1100,6 +1136,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.destroySecretVersion(request, options, callback);
   }
   setIamPolicy(
@@ -1125,8 +1162,8 @@ export class SecretManagerServiceClient {
    * Sets the access control policy on the specified secret. Replaces any
    * existing policy.
    *
-   * Permissions on [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] are enforced according
-   * to the policy set on the associated [Secret][google.cloud.secrets.v1beta1.Secret].
+   * Permissions on {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersions} are enforced according
+   * to the policy set on the associated {@link google.cloud.secrets.v1beta1.Secret|Secret}.
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -1173,6 +1210,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.setIamPolicy(request, options, callback);
   }
   getIamPolicy(
@@ -1243,6 +1281,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.getIamPolicy(request, options, callback);
   }
   testIamPermissions(
@@ -1318,6 +1357,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       resource: request.resource || '',
     });
+    this.initialize();
     return this._innerApiCalls.testIamPermissions(request, options, callback);
   }
 
@@ -1341,20 +1381,20 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
+   * Lists {@link google.cloud.secrets.v1beta1.Secret|Secrets}.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
    *   Required. The resource name of the project associated with the
-   *   [Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+   *   {@link google.cloud.secrets.v1beta1.Secret|Secrets}, in the format `projects/*`.
    * @param {number} [request.pageSize]
    *   Optional. The maximum number of results to be returned in a single page. If
    *   set to 0, the server decides the number of results to return. If the
    *   number is greater than 25000, it is capped at 25000.
    * @param {string} [request.pageToken]
    *   Optional. Pagination token, returned earlier via
-   *   [ListSecretsResponse.next_page_token][google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token].
+   *   {@link google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token|ListSecretsResponse.next_page_token}.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -1410,6 +1450,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listSecrets(request, options, callback);
   }
 
@@ -1430,14 +1471,14 @@ export class SecretManagerServiceClient {
    *   The request object that will be sent.
    * @param {string} request.parent
    *   Required. The resource name of the project associated with the
-   *   [Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+   *   {@link google.cloud.secrets.v1beta1.Secret|Secrets}, in the format `projects/*`.
    * @param {number} [request.pageSize]
    *   Optional. The maximum number of results to be returned in a single page. If
    *   set to 0, the server decides the number of results to return. If the
    *   number is greater than 25000, it is capped at 25000.
    * @param {string} [request.pageToken]
    *   Optional. Pagination token, returned earlier via
-   *   [ListSecretsResponse.next_page_token][google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token].
+   *   {@link google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token|ListSecretsResponse.next_page_token}.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -1457,6 +1498,7 @@ export class SecretManagerServiceClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listSecrets.createStream(
       this._innerApiCalls.listSecrets as gax.GaxCall,
       request,
@@ -1483,14 +1525,14 @@ export class SecretManagerServiceClient {
     >
   ): void;
   /**
-   * Lists [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion]. This call does not return secret
+   * Lists {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersions}. This call does not return secret
    * data.
    *
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the
-   *   [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.Secret|Secret} associated with the
+   *   {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersions} to list, in the format
    *   `projects/* /secrets/*`.
    * @param {number} [request.pageSize]
    *   Optional. The maximum number of results to be returned in a single page. If
@@ -1554,6 +1596,7 @@ export class SecretManagerServiceClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listSecretVersions(request, options, callback);
   }
 
@@ -1573,8 +1616,8 @@ export class SecretManagerServiceClient {
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
-   *   Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the
-   *   [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format
+   *   Required. The resource name of the {@link google.cloud.secrets.v1beta1.Secret|Secret} associated with the
+   *   {@link google.cloud.secrets.v1beta1.SecretVersion|SecretVersions} to list, in the format
    *   `projects/* /secrets/*`.
    * @param {number} [request.pageSize]
    *   Optional. The maximum number of results to be returned in a single page. If
@@ -1602,6 +1645,7 @@ export class SecretManagerServiceClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listSecretVersions.createStream(
       this._innerApiCalls.listSecretVersions as gax.GaxCall,
       request,
@@ -1709,8 +1753,9 @@ export class SecretManagerServiceClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.secretManagerServiceStub.then(stub => {
+      return this.secretManagerServiceStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,13 +1,13 @@
 {
-  "updateTime": "2020-02-29T12:40:05.062073Z",
+  "updateTime": "2020-03-05T23:15:16.840605Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "83c6f84035ee0f80eaa44d8b688a010461cc4080",
-        "internalRef": "297918498",
-        "log": "83c6f84035ee0f80eaa44d8b688a010461cc4080\nUpdate google/api/auth.proto to make AuthProvider to have JwtLocation\n\nPiperOrigin-RevId: 297918498\n\n"
+        "sha": "f0b581b5bdf803e45201ecdb3688b60e381628a8",
+        "internalRef": "299181282",
+        "log": "f0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n638253bf86d1ce1c314108a089b7351440c2f0bf\nfix: add java_multiple_files option for automl text_sentiment.proto\n\nPiperOrigin-RevId: 298971070\n\n373d655703bf914fb8b0b1cc4071d772bac0e0d1\nUpdate Recs AI Beta public bazel file\n\nPiperOrigin-RevId: 298961623\n\ndcc5d00fc8a8d8b56f16194d7c682027b2c66a3b\nfix: add java_multiple_files option for automl classification.proto\n\nPiperOrigin-RevId: 298953301\n\na3f791827266f3496a6a5201d58adc4bb265c2a3\nchore: automl/v1 publish annotations and retry config\n\nPiperOrigin-RevId: 298942178\n\n01c681586d8d6dbd60155289b587aee678530bd9\nMark return_immediately in PullRequest deprecated.\n\nPiperOrigin-RevId: 298893281\n\nc9f5e9c4bfed54bbd09227e990e7bded5f90f31c\nRemove out of date documentation for predicate support on the Storage API\n\nPiperOrigin-RevId: 298883309\n\nfd5b3b8238d783b04692a113ffe07c0363f5de0f\ngenerate webrisk v1 proto\n\nPiperOrigin-RevId: 298847934\n\n541b1ded4abadcc38e8178680b0677f65594ea6f\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 298686266\n\nc0d171acecb4f5b0bfd2c4ca34fc54716574e300\n  Updated to include the Notification v1 API.\n\nPiperOrigin-RevId: 298652775\n\n2346a9186c0bff2c9cc439f2459d558068637e05\nAdd Service Directory v1beta1 protos and configs\n\nPiperOrigin-RevId: 298625638\n\na78ed801b82a5c6d9c5368e24b1412212e541bb7\nPublishing v3 protos and configs.\n\nPiperOrigin-RevId: 298607357\n\n4a180bfff8a21645b3a935c2756e8d6ab18a74e0\nautoml/v1beta1 publish proto updates\n\nPiperOrigin-RevId: 298484782\n\n6de6e938b7df1cd62396563a067334abeedb9676\nchore: use the latest gapic-generator and protoc-java-resource-name-plugin in Bazel workspace.\n\nPiperOrigin-RevId: 298474513\n\n244ab2b83a82076a1fa7be63b7e0671af73f5c02\nAdds service config definition for bigqueryreservation v1\n\nPiperOrigin-RevId: 298455048\n\n"
       }
     },
     {

--- a/test/gapic-secret_manager_service-v1.ts
+++ b/test/gapic-secret_manager_service-v1.ts
@@ -85,6 +85,26 @@ describe('v1.SecretManagerServiceClient', () => {
     );
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new secretmanagerserviceModule.v1.SecretManagerServiceClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    assert.strictEqual(client.secretManagerServiceStub, undefined);
+    await client.initialize();
+    assert(client.secretManagerServiceStub);
+  });
+  it('has close method', () => {
+    const client = new secretmanagerserviceModule.v1.SecretManagerServiceClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    client.close();
+  });
   describe('createSecret', () => {
     it('invokes createSecret without error', done => {
       const client = new secretmanagerserviceModule.v1.SecretManagerServiceClient(
@@ -93,6 +113,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.ICreateSecretRequest = {};
       request.parent = '';
@@ -118,6 +140,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.ICreateSecretRequest = {};
       request.parent = '';
@@ -145,6 +169,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IAddSecretVersionRequest = {};
       request.parent = '';
@@ -170,6 +196,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IAddSecretVersionRequest = {};
       request.parent = '';
@@ -197,6 +225,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IGetSecretRequest = {};
       request.name = '';
@@ -222,6 +252,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IGetSecretRequest = {};
       request.name = '';
@@ -249,6 +281,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IUpdateSecretRequest = {};
       request.secret = {};
@@ -275,6 +309,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IUpdateSecretRequest = {};
       request.secret = {};
@@ -303,6 +339,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IDeleteSecretRequest = {};
       request.name = '';
@@ -328,6 +366,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IDeleteSecretRequest = {};
       request.name = '';
@@ -355,6 +395,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IGetSecretVersionRequest = {};
       request.name = '';
@@ -380,6 +422,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IGetSecretVersionRequest = {};
       request.name = '';
@@ -407,6 +451,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IAccessSecretVersionRequest = {};
       request.name = '';
@@ -432,6 +478,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IAccessSecretVersionRequest = {};
       request.name = '';
@@ -459,6 +507,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IDisableSecretVersionRequest = {};
       request.name = '';
@@ -484,6 +534,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IDisableSecretVersionRequest = {};
       request.name = '';
@@ -511,6 +563,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IEnableSecretVersionRequest = {};
       request.name = '';
@@ -536,6 +590,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IEnableSecretVersionRequest = {};
       request.name = '';
@@ -563,6 +619,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IDestroySecretVersionRequest = {};
       request.name = '';
@@ -588,6 +646,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IDestroySecretVersionRequest = {};
       request.name = '';
@@ -615,6 +675,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -640,6 +702,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -667,6 +731,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -692,6 +758,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -719,6 +787,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -744,6 +814,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -771,6 +843,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IListSecretsRequest = {};
       request.parent = '';
@@ -800,6 +874,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IListSecretsRequest = {};
       request.parent = '';
@@ -834,6 +910,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IListSecretVersionsRequest = {};
       request.parent = '';
@@ -863,6 +941,8 @@ describe('v1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secretmanager.v1.IListSecretVersionsRequest = {};
       request.parent = '';

--- a/test/gapic-secret_manager_service-v1beta1.ts
+++ b/test/gapic-secret_manager_service-v1beta1.ts
@@ -86,6 +86,26 @@ describe('v1beta1.SecretManagerServiceClient', () => {
     );
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new secretmanagerserviceModule.v1beta1.SecretManagerServiceClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    assert.strictEqual(client.secretManagerServiceStub, undefined);
+    await client.initialize();
+    assert(client.secretManagerServiceStub);
+  });
+  it('has close method', () => {
+    const client = new secretmanagerserviceModule.v1beta1.SecretManagerServiceClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    client.close();
+  });
   describe('createSecret', () => {
     it('invokes createSecret without error', done => {
       const client = new secretmanagerserviceModule.v1beta1.SecretManagerServiceClient(
@@ -94,6 +114,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.ICreateSecretRequest = {};
       request.parent = '';
@@ -119,6 +141,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.ICreateSecretRequest = {};
       request.parent = '';
@@ -146,6 +170,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IAddSecretVersionRequest = {};
       request.parent = '';
@@ -171,6 +197,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IAddSecretVersionRequest = {};
       request.parent = '';
@@ -198,6 +226,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IGetSecretRequest = {};
       request.name = '';
@@ -223,6 +253,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IGetSecretRequest = {};
       request.name = '';
@@ -250,6 +282,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IUpdateSecretRequest = {};
       request.secret = {};
@@ -276,6 +310,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IUpdateSecretRequest = {};
       request.secret = {};
@@ -304,6 +340,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IDeleteSecretRequest = {};
       request.name = '';
@@ -329,6 +367,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IDeleteSecretRequest = {};
       request.name = '';
@@ -356,6 +396,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IGetSecretVersionRequest = {};
       request.name = '';
@@ -381,6 +423,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IGetSecretVersionRequest = {};
       request.name = '';
@@ -408,6 +452,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IAccessSecretVersionRequest = {};
       request.name = '';
@@ -433,6 +479,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IAccessSecretVersionRequest = {};
       request.name = '';
@@ -460,6 +508,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IDisableSecretVersionRequest = {};
       request.name = '';
@@ -485,6 +535,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IDisableSecretVersionRequest = {};
       request.name = '';
@@ -512,6 +564,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IEnableSecretVersionRequest = {};
       request.name = '';
@@ -537,6 +591,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IEnableSecretVersionRequest = {};
       request.name = '';
@@ -564,6 +620,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IDestroySecretVersionRequest = {};
       request.name = '';
@@ -589,6 +647,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IDestroySecretVersionRequest = {};
       request.name = '';
@@ -616,6 +676,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -641,6 +703,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ISetIamPolicyRequest = {};
       request.resource = '';
@@ -668,6 +732,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -693,6 +759,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.IGetIamPolicyRequest = {};
       request.resource = '';
@@ -720,6 +788,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -745,6 +815,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.iam.v1.ITestIamPermissionsRequest = {};
       request.resource = '';
@@ -772,6 +844,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IListSecretsRequest = {};
       request.parent = '';
@@ -801,6 +875,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IListSecretsRequest = {};
       request.parent = '';
@@ -835,6 +911,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IListSecretVersionsRequest = {};
       request.parent = '';
@@ -864,6 +942,8 @@ describe('v1beta1.SecretManagerServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.secrets.v1beta1.IListSecretVersionsRequest = {};
       request.parent = '';


### PR DESCRIPTION
This PR includes changes from https://github.com/googleapis/gapic-generator-typescript/pull/317
that will move the asynchronous initialization and authentication from the client constructor
to an `initialize()` method. This method will be automatically called when the first RPC call
is performed.

The client library usage has not changed, there is no need to update any code.

If you want to make sure the client is authenticated _before_ the first RPC call, you can do
```js
await client.initialize();
```
manually before calling any client method.