### PR TITLE
fix(samples): correct usage of toString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ async function createAndAccessSecret() {
     name: version.name,
   });
 
-  const responsePayload = accessResponse.payload.data.toString('utf8');
+  const responsePayload = accessResponse.payload.data.toString();
   console.info(`Payload: ${responsePayload}`);
 }
 createAndAccessSecret();

--- a/samples/accessSecretVersion.js
+++ b/samples/accessSecretVersion.js
@@ -34,7 +34,7 @@ async function main(name = 'projects/my-project/secrets/my-secret/versions/1') {
     });
 
     // Extract the payload as a string.
-    const payload = version.payload.data.toString('utf8');
+    const payload = version.payload.data.toString();
 
     // WARNING: Do not print the secret in a production environment - this
     // snippet is showing how to access the secret material.


### PR DESCRIPTION
I did not make a corresponding issue ticket because this seemed like a small documentation fix and 🤞 the lengthy issue template is not needed. But I can change this if needed!

When accessing a secret version, the payload data is of type `string | Uint8Array`, neither of which accepts a character encoding option in their `toString()` function.

I am not sure if this is done because there is maybe some third, undocumented possible type of payload (like a Buffer?).

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-secret-manager/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

