### PR TITLE
experiment: test secrets with no credential file

### DIFF
--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -32,7 +32,6 @@ do
     --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
     gcr.io/google.com/cloudsdktool/cloud-sdk \
     secrets versions access latest \
-    --credential-file-override=${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json \
     --project cloud-devrel-kokoro-resources \
     --secret $key > \
     "$SECRET_LOCATION/$key"

--- a/.kokoro/presubmit/node10/system-test.cfg
+++ b/.kokoro/presubmit/node10/system-test.cfg
@@ -2,6 +2,11 @@
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
 
 env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "npm_publish_token,not_a_real_secret_testing_permissions"
+}
+
+env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-secret-manager/.kokoro/system-test.sh"
 }

--- a/.kokoro/system-test.sh
+++ b/.kokoro/system-test.sh
@@ -22,6 +22,10 @@ export NPM_CONFIG_PREFIX=/home/node/.npm-global
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
 export GCLOUD_PROJECT=long-door-651
 
+# Test the new logic for populating secrets from secret manager:
+cat $KOKORO_GFILE_DIR/secret_manager/not_a_real_secret_testing_permissions
+exit 0
+
 cd $(dirname $0)/..
 
 # Run a pre-test hook, if a pre-system-test.sh is in the project


### PR DESCRIPTION
confirm that a credentials file is no longer needed to populate secrets.