### PR TITLE
build: build cop was accidentally turned off when upgrading to trampoline_v2

### DIFF
--- a/.kokoro/samples-test.sh
+++ b/.kokoro/samples-test.sh
@@ -42,7 +42,7 @@ if [ -f samples/package.json ]; then
     # If tests are running against master, configure Build Cop
     # to open issues on failures:
     if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
-      export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+      export MOCHA_REPORTER_OUTPUT=js_test_output_sponge_log.xml
       export MOCHA_REPORTER=xunit
       cleanup() {
         chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop

--- a/.kokoro/system-test.sh
+++ b/.kokoro/system-test.sh
@@ -36,7 +36,7 @@ npm install
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
-  export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+  export MOCHA_REPORTER_OUTPUT=js_test_output_sponge_log.xml
   export MOCHA_REPORTER=xunit
   cleanup() {
     chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -24,7 +24,7 @@ npm install
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
-  export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+  export MOCHA_REPORTER_OUTPUT=js_test_output_sponge_log.xml
   export MOCHA_REPORTER=xunit
   cleanup() {
     chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -125,6 +125,8 @@ pass_down_envvars=(
     "TRAMPOLINE_CI"
     # Indicates the version of the script.
     "TRAMPOLINE_VERSION"
+    # Contains path to build artifacts being executed.
+    "KOKORO_BUILD_ARTIFACTS_SUBDIR"
 )
 
 log_yellow "Building with Trampoline ${TRAMPOLINE_VERSION}"
@@ -408,7 +410,6 @@ docker_flags=(
     "--volume" "${PROJECT_ROOT}:${TRAMPOLINE_WORKSPACE}"
     "--workdir" "${TRAMPOLINE_WORKSPACE}"
     "--env" "PROJECT_ROOT=${TRAMPOLINE_WORKSPACE}"
-    "--env" "KOKORO_BUILD_ARTIFACTS_SUBDIR=${KOKORO_BUILD_ARTIFACTS_SUBDIR}"
 
     # Mount the temporary home directory.
     "--volume" "${tmphome}:/h"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -408,6 +408,7 @@ docker_flags=(
     "--volume" "${PROJECT_ROOT}:${TRAMPOLINE_WORKSPACE}"
     "--workdir" "${TRAMPOLINE_WORKSPACE}"
     "--env" "PROJECT_ROOT=${TRAMPOLINE_WORKSPACE}"
+    "--env" "KOKORO_BUILD_ARTIFACTS_SUBDIR=${KOKORO_BUILD_ARTIFACTS_SUBDIR}"
 
     # Mount the temporary home directory.
     "--volume" "${tmphome}:/h"


### PR DESCRIPTION
* add the environment variable build cop checks to `pass_down_envvars`.
* also prefix our sponge log with `js` on a hunch that this might properly populate the language field.