### PR TITLE
fix: do not modify options object, use defaultScopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "api-documenter": "api-documenter yaml --input-folder=temp"
   },
   "dependencies": {
-    "google-gax": "^2.1.0"
+    "google-gax": "^2.9.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import * as v1 from './v1';
 import * as v1beta1 from './v1beta1';
 
 const SecretManagerServiceClient = v1.SecretManagerServiceClient;
+type SecretManagerServiceClient = v1.SecretManagerServiceClient;
 
 export {v1, v1beta1, SecretManagerServiceClient};
 export default {v1, v1beta1, SecretManagerServiceClient};

--- a/src/v1/secret_manager_service_client.ts
+++ b/src/v1/secret_manager_service_client.ts
@@ -66,8 +66,10 @@ export class SecretManagerServiceClient {
   /**
    * Construct an instance of SecretManagerServiceClient.
    *
-   * @param {object} [options] - The configuration object. See the subsequent
-   *   parameters for more details.
+   * @param {object} [options] - The configuration object.
+   * The options accepted by the constructor are described in detail
+   * in [this document](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#creating-the-client-instance).
+   * The common options are:
    * @param {object} [options.credentials] - Credentials object.
    * @param {string} [options.credentials.client_email]
    * @param {string} [options.credentials.private_key]
@@ -87,43 +89,33 @@ export class SecretManagerServiceClient {
    *     your project ID will be detected automatically.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
+   * @param {gax.ClientConfig} [options.clientConfig] - client configuration override.
+   *     TODO(@alexander-fenster): link to gax documentation.
+   * @param {boolean} fallback - Use HTTP fallback mode.
+   *     In fallback mode, a special browser-compatible transport implementation is used
+   *     instead of gRPC transport. In browser context (if the `window` object is defined)
+   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
+   *     if you need to override this behavior.
    */
-
   constructor(opts?: ClientOptions) {
-    // Ensure that options include the service address and port.
+    // Ensure that options include all the required fields.
     const staticMembers = this.constructor as typeof SecretManagerServiceClient;
     const servicePath =
-      opts && opts.servicePath
-        ? opts.servicePath
-        : opts && opts.apiEndpoint
-        ? opts.apiEndpoint
-        : staticMembers.servicePath;
-    const port = opts && opts.port ? opts.port : staticMembers.port;
+      opts?.servicePath || opts?.apiEndpoint || staticMembers.servicePath;
+    const port = opts?.port || staticMembers.port;
+    const clientConfig = opts?.clientConfig ?? {};
+    const fallback = opts?.fallback ?? typeof window !== 'undefined';
+    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
 
-    if (!opts) {
-      opts = {servicePath, port};
+    // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
+    if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
+      opts['scopes'] = staticMembers.scopes;
     }
-    opts.servicePath = opts.servicePath || servicePath;
-    opts.port = opts.port || port;
 
-    // users can override the config from client side, like retry codes name.
-    // The detailed structure of the clientConfig can be found here: https://github.com/googleapis/gax-nodejs/blob/master/src/gax.ts#L546
-    // The way to override client config for Showcase API:
-    //
-    // const customConfig = {"interfaces": {"google.showcase.v1beta1.Echo": {"methods": {"Echo": {"retry_codes_name": "idempotent", "retry_params_name": "default"}}}}}
-    // const showcaseClient = new showcaseClient({ projectId, customConfig });
-    opts.clientConfig = opts.clientConfig || {};
-
-    // If we're running in browser, it's OK to omit `fallback` since
-    // google-gax has `browser` field in its `package.json`.
-    // For Electron (which does not respect `browser` field),
-    // pass `{fallback: true}` to the SecretManagerServiceClient constructor.
+    // Choose either gRPC or proto-over-HTTP implementation of google-gax.
     this._gaxModule = opts.fallback ? gax.fallback : gax;
 
-    // Create a `gaxGrpc` object, with any grpc-specific options
-    // sent to the client.
-    opts.scopes = (this
-      .constructor as typeof SecretManagerServiceClient).scopes;
+    // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
 
     // Save options to use in initialize() method.
@@ -131,6 +123,11 @@ export class SecretManagerServiceClient {
 
     // Save the auth object to the client, for use by other methods.
     this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
+
+    // Set the default scopes in auth client if needed.
+    if (servicePath === staticMembers.servicePath) {
+      this.auth.defaultScopes = staticMembers.scopes;
+    }
 
     // Determine the client header string.
     const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
@@ -286,6 +283,7 @@ export class SecretManagerServiceClient {
 
   /**
    * The DNS address for this API service.
+   * @returns {string} The DNS address for this service.
    */
   static get servicePath() {
     return 'secretmanager.googleapis.com';
@@ -294,6 +292,7 @@ export class SecretManagerServiceClient {
   /**
    * The DNS address for this API service - same as servicePath(),
    * exists for compatibility reasons.
+   * @returns {string} The DNS address for this service.
    */
   static get apiEndpoint() {
     return 'secretmanager.googleapis.com';
@@ -301,6 +300,7 @@ export class SecretManagerServiceClient {
 
   /**
    * The port for this API service.
+   * @returns {number} The default port for this service.
    */
   static get port() {
     return 443;
@@ -309,6 +309,7 @@ export class SecretManagerServiceClient {
   /**
    * The scopes needed to make gRPC calls for every method defined
    * in this service.
+   * @returns {string[]} List of default scopes.
    */
   static get scopes() {
     return ['https://www.googleapis.com/auth/cloud-platform'];
@@ -318,8 +319,7 @@ export class SecretManagerServiceClient {
   getProjectId(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
-   * @param {function(Error, string)} callback - the callback to
-   *   be called with the current project Id.
+   * @returns {Promise} A promise that resolves to string containing the project ID.
    */
   getProjectId(
     callback?: Callback<string, undefined, undefined>
@@ -385,7 +385,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Secret]{@link google.cloud.secretmanager.v1.Secret}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.createSecret(request);
    */
   createSecret(
     request: protos.google.cloud.secretmanager.v1.ICreateSecretRequest,
@@ -477,7 +481,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.addSecretVersion(request);
    */
   addSecretVersion(
     request: protos.google.cloud.secretmanager.v1.IAddSecretVersionRequest,
@@ -561,7 +569,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Secret]{@link google.cloud.secretmanager.v1.Secret}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.getSecret(request);
    */
   getSecret(
     request: protos.google.cloud.secretmanager.v1.IGetSecretRequest,
@@ -649,7 +661,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Secret]{@link google.cloud.secretmanager.v1.Secret}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.updateSecret(request);
    */
   updateSecret(
     request: protos.google.cloud.secretmanager.v1.IUpdateSecretRequest,
@@ -738,7 +754,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.deleteSecret(request);
    */
   deleteSecret(
     request: protos.google.cloud.secretmanager.v1.IDeleteSecretRequest,
@@ -832,7 +852,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.getSecretVersion(request);
    */
   getSecretVersion(
     request: protos.google.cloud.secretmanager.v1.IGetSecretVersionRequest,
@@ -927,7 +951,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [AccessSecretVersionResponse]{@link google.cloud.secretmanager.v1.AccessSecretVersionResponse}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.accessSecretVersion(request);
    */
   accessSecretVersion(
     request: protos.google.cloud.secretmanager.v1.IAccessSecretVersionRequest,
@@ -1025,7 +1053,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.disableSecretVersion(request);
    */
   disableSecretVersion(
     request: protos.google.cloud.secretmanager.v1.IDisableSecretVersionRequest,
@@ -1123,7 +1155,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.enableSecretVersion(request);
    */
   enableSecretVersion(
     request: protos.google.cloud.secretmanager.v1.IEnableSecretVersionRequest,
@@ -1222,7 +1258,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.destroySecretVersion(request);
    */
   destroySecretVersion(
     request: protos.google.cloud.secretmanager.v1.IDestroySecretVersionRequest,
@@ -1319,7 +1359,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Policy]{@link google.iam.v1.Policy}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.setIamPolicy(request);
    */
   setIamPolicy(
     request: protos.google.iam.v1.ISetIamPolicyRequest,
@@ -1404,7 +1448,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [Policy]{@link google.iam.v1.Policy}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.getIamPolicy(request);
    */
   getIamPolicy(
     request: protos.google.iam.v1.IGetIamPolicyRequest,
@@ -1496,7 +1544,11 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is an object representing [TestIamPermissionsResponse]{@link google.iam.v1.TestIamPermissionsResponse}.
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.testIamPermissions(request);
    */
   testIamPermissions(
     request: protos.google.iam.v1.ITestIamPermissionsRequest,
@@ -1589,19 +1641,14 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is Array of [Secret]{@link google.cloud.secretmanager.v1.Secret}.
-   *   The client library support auto-pagination by default: it will call the API as many
+   *   The client library will perform auto-pagination by default: it will call the API as many
    *   times as needed and will merge results from all the pages into this array.
-   *
-   *   When autoPaginate: false is specified through options, the array has three elements.
-   *   The first element is Array of [Secret]{@link google.cloud.secretmanager.v1.Secret} that corresponds to
-   *   the one page received from the API server.
-   *   If the second element is not null it contains the request object of type [ListSecretsRequest]{@link google.cloud.secretmanager.v1.ListSecretsRequest}
-   *   that can be used to obtain the next page of the results.
-   *   If it is null, the next page does not exist.
-   *   The third element contains the raw response received from the API server. Its type is
-   *   [ListSecretsResponse]{@link google.cloud.secretmanager.v1.ListSecretsResponse}.
-   *
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Note that it can affect your quota.
+   *   We recommend using `listSecretsAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listSecrets(
     request: protos.google.cloud.secretmanager.v1.IListSecretsRequest,
@@ -1649,18 +1696,7 @@ export class SecretManagerServiceClient {
   }
 
   /**
-   * Equivalent to {@link listSecrets}, but returns a NodeJS Stream object.
-   *
-   * This fetches the paged responses for {@link listSecrets} continuously
-   * and invokes the callback registered for 'data' event for each element in the
-   * responses.
-   *
-   * The returned object has 'end' method when no more elements are required.
-   *
-   * autoPaginate option will be ignored.
-   *
-   * @see {@link https://nodejs.org/api/stream.html}
-   *
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
@@ -1677,6 +1713,13 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
    *   An object stream which emits an object representing [Secret]{@link google.cloud.secretmanager.v1.Secret} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `listSecretsAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listSecretsStream(
     request?: protos.google.cloud.secretmanager.v1.IListSecretsRequest,
@@ -1701,10 +1744,9 @@ export class SecretManagerServiceClient {
   }
 
   /**
-   * Equivalent to {@link listSecrets}, but returns an iterable object.
+   * Equivalent to `listSecrets`, but returns an iterable object.
    *
-   * for-await-of syntax is used with the iterable to recursively get response element on-demand.
-   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
@@ -1720,7 +1762,18 @@ export class SecretManagerServiceClient {
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
-   *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [Secret]{@link google.cloud.secretmanager.v1.Secret}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.listSecretsAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
    */
   listSecretsAsync(
     request?: protos.google.cloud.secretmanager.v1.IListSecretsRequest,
@@ -1796,19 +1849,14 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
    *   The first element of the array is Array of [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion}.
-   *   The client library support auto-pagination by default: it will call the API as many
+   *   The client library will perform auto-pagination by default: it will call the API as many
    *   times as needed and will merge results from all the pages into this array.
-   *
-   *   When autoPaginate: false is specified through options, the array has three elements.
-   *   The first element is Array of [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion} that corresponds to
-   *   the one page received from the API server.
-   *   If the second element is not null it contains the request object of type [ListSecretVersionsRequest]{@link google.cloud.secretmanager.v1.ListSecretVersionsRequest}
-   *   that can be used to obtain the next page of the results.
-   *   If it is null, the next page does not exist.
-   *   The third element contains the raw response received from the API server. Its type is
-   *   [ListSecretVersionsResponse]{@link google.cloud.secretmanager.v1.ListSecretVersionsResponse}.
-   *
-   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *   Note that it can affect your quota.
+   *   We recommend using `listSecretVersionsAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listSecretVersions(
     request: protos.google.cloud.secretmanager.v1.IListSecretVersionsRequest,
@@ -1856,18 +1904,7 @@ export class SecretManagerServiceClient {
   }
 
   /**
-   * Equivalent to {@link listSecretVersions}, but returns a NodeJS Stream object.
-   *
-   * This fetches the paged responses for {@link listSecretVersions} continuously
-   * and invokes the callback registered for 'data' event for each element in the
-   * responses.
-   *
-   * The returned object has 'end' method when no more elements are required.
-   *
-   * autoPaginate option will be ignored.
-   *
-   * @see {@link https://nodejs.org/api/stream.html}
-   *
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
@@ -1885,6 +1922,13 @@ export class SecretManagerServiceClient {
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
    *   An object stream which emits an object representing [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `listSecretVersionsAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
    */
   listSecretVersionsStream(
     request?: protos.google.cloud.secretmanager.v1.IListSecretVersionsRequest,
@@ -1909,10 +1953,9 @@ export class SecretManagerServiceClient {
   }
 
   /**
-   * Equivalent to {@link listSecretVersions}, but returns an iterable object.
+   * Equivalent to `listSecretVersions`, but returns an iterable object.
    *
-   * for-await-of syntax is used with the iterable to recursively get response element on-demand.
-   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
    * @param {Object} request
    *   The request object that will be sent.
    * @param {string} request.parent
@@ -1929,7 +1972,18 @@ export class SecretManagerServiceClient {
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Object}
-   *   An iterable Object that conforms to @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols.
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [SecretVersion]{@link google.cloud.secretmanager.v1.SecretVersion}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.listSecretVersionsAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
    */
   listSecretVersionsAsync(
     request?: protos.google.cloud.secretmanager.v1.IListSecretVersionsRequest,
@@ -2069,9 +2123,10 @@ export class SecretManagerServiceClient {
   }
 
   /**
-   * Terminate the GRPC channel and close the client.
+   * Terminate the gRPC channel and close the client.
    *
    * The client will no longer be usable and all future behavior is undefined.
+   * @returns {Promise} A promise that resolves when the client is closed.
    */
   close(): Promise<void> {
     this.initialize();

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-secret-manager.git",
-        "sha": "07e726a6e1ad97554ddf8aa58cb79e940ccaefb7"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "f17ea338b502b967101ca71e4ff0f11d8d1e4518",
-        "internalRef": "330793532"
+        "remote": "git@github.com:googleapis/nodejs-secret-manager",
+        "sha": "f3cf178ae7a880f777ebf55eb22466c94c8ff34d"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "ba9918cd22874245b55734f57470c719b577e591"
+        "sha": "3d3e94c4e02370f307a9a200b0c743c3d8d19f29"
       }
     }
   ],
@@ -42,84 +34,5 @@
         "generator": "bazel"
       }
     }
-  ],
-  "generatedFiles": [
-    ".eslintignore",
-    ".eslintrc.json",
-    ".gitattributes",
-    ".github/ISSUE_TEMPLATE/bug_report.md",
-    ".github/ISSUE_TEMPLATE/feature_request.md",
-    ".github/ISSUE_TEMPLATE/support_request.md",
-    ".github/PULL_REQUEST_TEMPLATE.md",
-    ".github/release-please.yml",
-    ".github/workflows/ci.yaml",
-    ".gitignore",
-    ".jsdoc.js",
-    ".kokoro/.gitattributes",
-    ".kokoro/common.cfg",
-    ".kokoro/continuous/node10/common.cfg",
-    ".kokoro/continuous/node10/docs.cfg",
-    ".kokoro/continuous/node10/test.cfg",
-    ".kokoro/continuous/node12/common.cfg",
-    ".kokoro/continuous/node12/lint.cfg",
-    ".kokoro/continuous/node12/samples-test.cfg",
-    ".kokoro/continuous/node12/system-test.cfg",
-    ".kokoro/continuous/node12/test.cfg",
-    ".kokoro/docs.sh",
-    ".kokoro/lint.sh",
-    ".kokoro/populate-secrets.sh",
-    ".kokoro/presubmit/node10/common.cfg",
-    ".kokoro/presubmit/node12/common.cfg",
-    ".kokoro/presubmit/node12/samples-test.cfg",
-    ".kokoro/presubmit/node12/system-test.cfg",
-    ".kokoro/presubmit/node12/test.cfg",
-    ".kokoro/publish.sh",
-    ".kokoro/release/docs-devsite.cfg",
-    ".kokoro/release/docs-devsite.sh",
-    ".kokoro/release/docs.cfg",
-    ".kokoro/release/docs.sh",
-    ".kokoro/release/publish.cfg",
-    ".kokoro/samples-test.sh",
-    ".kokoro/system-test.sh",
-    ".kokoro/test.bat",
-    ".kokoro/test.sh",
-    ".kokoro/trampoline.sh",
-    ".kokoro/trampoline_v2.sh",
-    ".mocharc.js",
-    ".nycrc",
-    ".prettierignore",
-    ".prettierrc.js",
-    ".trampolinerc",
-    "CODE_OF_CONDUCT.md",
-    "CONTRIBUTING.md",
-    "LICENSE",
-    "README.md",
-    "api-extractor.json",
-    "linkinator.config.json",
-    "protos/google/cloud/secretmanager/v1/resources.proto",
-    "protos/google/cloud/secretmanager/v1/service.proto",
-    "protos/google/cloud/secrets/v1beta1/resources.proto",
-    "protos/google/cloud/secrets/v1beta1/service.proto",
-    "protos/protos.d.ts",
-    "protos/protos.js",
-    "protos/protos.json",
-    "renovate.json",
-    "samples/README.md",
-    "src/index.ts",
-    "src/v1/index.ts",
-    "src/v1/secret_manager_service_client.ts",
-    "src/v1/secret_manager_service_client_config.json",
-    "src/v1/secret_manager_service_proto_list.json",
-    "src/v1beta1/index.ts",
-    "src/v1beta1/secret_manager_service_client.ts",
-    "src/v1beta1/secret_manager_service_client_config.json",
-    "src/v1beta1/secret_manager_service_proto_list.json",
-    "system-test/fixtures/sample/src/index.js",
-    "system-test/fixtures/sample/src/index.ts",
-    "system-test/install.ts",
-    "test/gapic_secret_manager_service_v1.ts",
-    "test/gapic_secret_manager_service_v1beta1.ts",
-    "tsconfig.json",
-    "webpack.config.js"
   ]
 }

--- a/system-test/fixtures/sample/src/index.ts
+++ b/system-test/fixtures/sample/src/index.ts
@@ -18,8 +18,17 @@
 
 import {SecretManagerServiceClient} from '@google-cloud/secret-manager';
 
+// check that the client class type name can be used
+function doStuffWithSecretManagerServiceClient(
+  client: SecretManagerServiceClient
+) {
+  client.close();
+}
+
 function main() {
-  new SecretManagerServiceClient();
+  // check that the client instance can be created
+  const secretManagerServiceClient = new SecretManagerServiceClient();
+  doStuffWithSecretManagerServiceClient(secretManagerServiceClient);
 }
 
 main();

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -20,32 +20,32 @@ import {packNTest} from 'pack-n-play';
 import {readFileSync} from 'fs';
 import {describe, it} from 'mocha';
 
-describe('typescript consumer tests', () => {
-  it('should have correct type signature for typescript users', async function () {
+describe('📦 pack-n-play test', () => {
+  it('TypeScript code', async function () {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(), // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.ts'
         ).toString(),
       },
     };
-    await packNTest(options); // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function () {
+  it('JavaScript code', async function () {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(), // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.js'
         ).toString(),
       },
     };
-    await packNTest(options); // will throw upon error.
+    await packNTest(options);
   });
 });


### PR DESCRIPTION
This library was generated by gapic-generator-typescipt v1.2.0. Let's see how it works and then I'll update all libraries to use this version.

Note that we need to bump `google-gax` to `^2.9.2` to make this change safe for users.