### PR TITLE
build: Add a `generate-files-bot` config

### DIFF
--- a/.github/generated-files-bot.yml
+++ b/.github/generated-files-bot.yml
@@ -6,6 +6,6 @@ generatedFiles:
 - path: '.github/workflows/**'
   message: '`.github/workflows` (GitHub Actions) should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
 - path: 'README.md'
-  message: '`README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README. Ex: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'
+  message: '`README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'
 - path: 'samples/README.md'
-  message: '`samples/README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README. Ex: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'
+  message: '`samples/README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'

--- a/.github/generated-files-bot.yml
+++ b/.github/generated-files-bot.yml
@@ -1,0 +1,11 @@
+generatedFiles:
+- path: '.kokoro/**'
+  message: '`.kokoro` files are templated and should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
+- path: '.github/CODEOWNERS'
+  message: 'CODEOWNERS should instead be modified via the `codeowner_team` property in .repo-metadata.json'
+- path: '.github/workflows/**'
+  message: '`.github/workflows` (GitHub Actions) should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
+- path: 'README.md'
+  message: '`README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README. Ex: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'
+- path: 'samples/README.md'
+  message: '`samples/README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README. Ex: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'


### PR DESCRIPTION
Adding a config for `generate-files-bot` to help avoid accidental changes to generated files.