### PR TITLE
samples: Update getSecret sample to include version

### DIFF
--- a/samples/getSecret.js
+++ b/samples/getSecret.js
@@ -19,7 +19,7 @@ async function main(name = 'projects/my-project/secrets/my-secret') {
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */
-  // const name = 'projects/my-project/secrets/my-secret';
+  // const name = 'projects/my-project/secrets/my-secret/versions/my-version';
 
   // Imports the Secret Manager library
   const {SecretManagerServiceClient} = require('@google-cloud/secret-manager');


### PR DESCRIPTION
I struggled to get the samples running since I was missing `versions/*` which seems to be required now. I figured this change might help someone else in the future. Since just a small doc update so I felt it'd be overkill to open an issue, feel free to just close this PR if it's not helpful. 
