### PR TITLE
testing: skip `pull_request` build for PRs from a fork

### DIFF
--- a/.github/workflows/samples-test.yaml
+++ b/.github/workflows/samples-test.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: actions-samples-test
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:force-run' }}
+    if: ${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'actions:force-run' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'write'


### PR DESCRIPTION
The `if` block:

(github.event.action != 'labeled' &&
  github.event.pull_request.head.repo.full_name ==
    github.event.pull_request.base.repo.full_name) ||
  github.event.label.name == 'actions:force-run'

It should work because the `pull_request` build doesn't get triggered by the label event.
